### PR TITLE
feat: Add LibMan configuration and usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,37 @@ Beagl is an open source application to help animal service organizations manage 
 2. Install dependencies
 3. Run the app
 
+## Client-side Library Management (LibMan)
+
+This project uses [LibMan (Library Manager)](https://learn.microsoft.com/en-us/aspnet/core/client-side/libman/) to manage client-side libraries.
+
+### Installing the LibMan CLI
+
+If you don't have the LibMan CLI installed, you can install it globally using the following command:
+
+```sh
+dotnet tool install -g Microsoft.Web.LibraryManager.Cli
+```
+
+### Common Commands
+
+- **Restore libraries:**
+  ```sh
+  libman restore
+  ```
+- **Add a library:**
+  ```sh
+  libman install <library-name> --provider cdnjs
+  ```
+- **Clean libraries:**
+  ```sh
+  libman clean
+  ```
+
+Library configuration is stored in `libman.json` at the project root (or in the relevant web project folder).
+
+For more details, see the [LibMan documentation](https://learn.microsoft.com/en-us/aspnet/core/client-side/libman/libman-cli).
+
 ## Contributing
 
 We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/src/Beagl.WebApp/libman.json
+++ b/src/Beagl.WebApp/libman.json
@@ -1,0 +1,5 @@
+{
+  "version": "3.0",
+  "defaultProvider": "cdnjs",
+  "libraries": []
+}


### PR DESCRIPTION
Refs: #13

# Pull Request

## PR Title (Conventional Commits)
feat: Add LibMan configuration and usage instructions to README

## Description
This pull request introduces the use of LibMan (Library Manager) for managing client-side libraries in the project. It includes updates to the documentation and the addition of a `libman.json` configuration file.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18-R48): Added a new section explaining the use of LibMan for client-side library management. This includes instructions for installing the LibMan CLI, common commands (e.g., restoring libraries, adding libraries, and cleaning libraries), and a reference to the `libman.json` configuration file.

### Configuration File Addition:

* [`src/Beagl.WebApp/libman.json`](diffhunk://#diff-ad0a90262e273436588ab50abac5797d5359e46e6fd797d63d9fcff1407ec365R1-R5): Added a new `libman.json` configuration file to define the default provider (`cdnjs`) and manage client-side libraries.

## Checklist
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added or updated (if relevant)
- [x] Docs updated (if relevant)

## Related issues
Closes #13 
