### PR TITLE
feat: implement database initialization and role seeding functionality

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -73,6 +73,7 @@ file_header_template = MIT License - Copyright (c) 2025 Jonathan St-Michel
 # Require XML documentation for publicly visible types and members
 dotnet_diagnostic.CS1591.severity = warning
 dotnet_diagnostic.CA1812.severity = none
+dotnet_diagnostic.CA2007.severity = none
 
 # (Optional) You can change 'warning' to 'error' to be stricter
 # dotnet_diagnostic.CS1591.severity = error

--- a/README.md
+++ b/README.md
@@ -48,6 +48,27 @@ For more details, see the [LibMan documentation](https://learn.microsoft.com/en-
 
 ---
 
+## Seeding the Default Admin User with User Secrets
+
+To avoid storing sensitive data in source code, you should use [dotnet user-secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets) for development. This allows you to provide the default admin user's credentials securely for seeding.
+
+### Setting User Secrets
+
+
+From the `src/Beagl.WebApp` folder, run:
+
+```sh
+dotnet user-secrets init
+dotnet user-secrets set "SeedData:SeedUser:Email" "admin@localhost"
+dotnet user-secrets set "SeedData:SeedUser:Password" "your-strong-password"
+```
+
+Replace `your-strong-password` with a secure password of your choice.
+
+Your application will read these values from configuration when seeding the database.
+
+---
+
 ## Entity Framework Core (EF Core) & SQLite
 
 This project uses [Entity Framework Core 8](https://learn.microsoft.com/en-us/ef/core/) with SQLite as the development database provider.

--- a/src/Beagl.Domain/Entities/RoleNames.cs
+++ b/src/Beagl.Domain/Entities/RoleNames.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace Beagl.Domain.Entities;
+
+/// <summary>
+/// Provides constant role names used throughout the application for authorization and identity management.
+/// </summary>
+public static class RoleNames
+{
+    /// <summary>
+    /// The administrator role, with full access to all features and settings.
+    /// </summary>
+    public const string Administrator = "Administrator";
+
+    /// <summary>
+    /// The control role, typically for animal control officers.
+    /// </summary>
+    public const string Control = "Control";
+
+    /// <summary>
+    /// The employee role, for general staff members.
+    /// </summary>
+    public const string Employee = "Employee";
+
+    /// <summary>
+    /// The security role, for users responsible for security operations.
+    /// </summary>
+    public const string Security = "Security";
+
+    /// <summary>
+    /// The development role, for users involved in software or technical development.
+    /// </summary>
+    public const string Development = "Development";
+
+    /// <summary>
+    /// The marketing role, for users handling marketing activities.
+    /// </summary>
+    public const string Marketing = "Marketing";
+
+    /// <summary>
+    /// The finance role, for users managing financial operations.
+    /// </summary>
+    public const string Finance = "Finance";
+
+    /// <summary>
+    /// The board member role, for members of the organization's board.
+    /// </summary>
+    public const string BoardMember = "Board Member";
+
+    /// <summary>
+    /// The sales role, for users involved in sales activities.
+    /// </summary>
+    public const string Sales = "Sales";
+
+    /// <summary>
+    /// The citizen role, for external users.
+    /// </summary>
+    public const string Citizen = "Citizen";
+}

--- a/src/Beagl.Infrastructure/DatabaseInitializer.cs
+++ b/src/Beagl.Infrastructure/DatabaseInitializer.cs
@@ -1,0 +1,85 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Beagl.Domain.Entities;
+
+namespace Beagl.Infrastructure;
+
+/// <summary>
+/// Provides methods to initialize the application's database, apply migrations, and seed default roles and users.
+/// </summary>
+public static class DatabaseInitializer
+{
+    /// <summary>
+    /// Applies pending migrations and seeds default roles and users using configuration values.
+    /// </summary>
+    /// <param name="serviceProvider">The application's service provider.</param>
+    /// <param name="configuration">The configuration containing seed data.</param>
+    public static async Task InitializeAsync(IServiceProvider serviceProvider, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        using IServiceScope scope = serviceProvider.CreateScope();
+        ApplicationDbContext db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        await db.Database.MigrateAsync();
+
+        UserManager<IdentityUser> userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        RoleManager<IdentityRole> roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+
+        // Create default roles
+        await CreateRoleIfNotExistsAsync(roleManager, RoleNames.Administrator);
+        await CreateRoleIfNotExistsAsync(roleManager, RoleNames.Control);
+        await CreateRoleIfNotExistsAsync(roleManager, RoleNames.Employee);
+        await CreateRoleIfNotExistsAsync(roleManager, RoleNames.Security);
+        await CreateRoleIfNotExistsAsync(roleManager, RoleNames.Development);
+        await CreateRoleIfNotExistsAsync(roleManager, RoleNames.Marketing);
+        await CreateRoleIfNotExistsAsync(roleManager, RoleNames.Finance);
+        await CreateRoleIfNotExistsAsync(roleManager, RoleNames.BoardMember);
+        await CreateRoleIfNotExistsAsync(roleManager, RoleNames.Sales);
+        await CreateRoleIfNotExistsAsync(roleManager, RoleNames.Citizen);
+
+        // Create default user
+        string adminEmail = configuration["SeedData:SeedUser:Email"] ?? string.Empty;
+        string adminPassword = configuration["SeedData:SeedUser:Password"] ?? string.Empty;
+        await CreateUserIfNotExistsAsync(
+            userManager,
+            adminEmail,
+            adminPassword,
+            RoleNames.Development);
+    }
+
+    private static async Task CreateRoleIfNotExistsAsync(
+        RoleManager<IdentityRole> roleManager,
+        string roleName)
+    {
+        if (!await roleManager.RoleExistsAsync(roleName))
+        {
+            await roleManager.CreateAsync(new IdentityRole(roleName));
+        }
+    }
+
+    private static async Task CreateUserIfNotExistsAsync(
+        UserManager<IdentityUser> userManager,
+        string email,
+        string password,
+        string roleName)
+    {
+        IdentityUser? user = await userManager.FindByEmailAsync(email);
+        if (user == null)
+        {
+            user = new IdentityUser
+            {
+                UserName = email,
+                Email = email,
+                EmailConfirmed = true
+            };
+
+            IdentityResult result = await userManager.CreateAsync(user, password);
+            if (result.Succeeded)
+            {
+                await userManager.AddToRoleAsync(user, roleName);
+            }
+        }
+    }
+}

--- a/src/Beagl.WebApp/Beagl.WebApp.csproj
+++ b/src/Beagl.WebApp/Beagl.WebApp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
     <ProjectReference Include="..\Beagl.Infrastructure\Beagl.Infrastructure.csproj" />
@@ -24,6 +24,7 @@
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <AnalysisLevel>latest</AnalysisLevel>
     <Version>0.1.0</Version>
+    <UserSecretsId>465ec1fe-74d7-4aca-87f2-542872a4a5ec</UserSecretsId>
   </PropertyGroup>
 
 </Project>

--- a/src/Beagl.WebApp/Program.cs
+++ b/src/Beagl.WebApp/Program.cs
@@ -1,6 +1,7 @@
 // MIT License - Copyright (c) 2025 Jonathan St-Michel
 
 using Beagl.WebApp.Components;
+using Beagl.WebApp;
 using Beagl.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity;
@@ -32,6 +33,9 @@ builder.Services.ConfigureApplicationCookie(options =>
 
 WebApplication app = builder.Build();
 
+// Ensure database is created and migrations are applied at startup
+await app.ExecuteMigrationsAsync(builder.Configuration);
+
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {
@@ -49,4 +53,4 @@ app.UseAuthorization();
 
 app.MapRazorComponents<App>();
 
-app.Run();
+await app.RunAsync().ConfigureAwait(false);

--- a/src/Beagl.WebApp/WebApplicationExtensions.cs
+++ b/src/Beagl.WebApp/WebApplicationExtensions.cs
@@ -1,0 +1,22 @@
+using Beagl.Infrastructure;
+
+namespace Beagl.WebApp;
+
+/// <summary>
+/// Provides extension methods for the <see cref="WebApplication"/> class to support application startup tasks.
+/// </summary>
+internal static class WebApplicationExtensions
+{
+    /// <summary>
+    /// Applies any pending database migrations and seeds initial data using the provided configuration.
+    /// </summary>
+    /// <param name="app">The web application instance.</param>
+    /// <param name="configuration">The application configuration containing seed data and other settings.</param>
+    public static async Task ExecuteMigrationsAsync(this WebApplication app, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        await DatabaseInitializer.InitializeAsync(app.Services, configuration).ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
This pull request introduces infrastructure for secure database seeding and role management, along with improvements to application startup and configuration. The main changes include adding a centralized set of role constants, implementing a database initializer to apply migrations and seed roles/users, and integrating user secrets for secure admin credentials during development. Application startup now ensures migrations and seeding are executed automatically.

**Database initialization and seeding:**

* Added `DatabaseInitializer` in `src/Beagl.Infrastructure/DatabaseInitializer.cs` to apply migrations and seed default roles and a development user using configuration values.
* Introduced `WebApplicationExtensions.ExecuteMigrationsAsync` in `src/Beagl.WebApp/WebApplicationExtensions.cs` to trigger database initialization at application startup. [[1]](diffhunk://#diff-45587c4ed9823b265aae561a2504d75e8ccfc87ef4656aace6fbe34da87e23b5R1-R22) [[2]](diffhunk://#diff-5026c185f013fab3d8dbea67fdce916300fd31aa36c1c93cc228dd0dc62f958bR36-R38)

**Role management:**

* Added `RoleNames` static class in `src/Beagl.Domain/Entities/RoleNames.cs` to centralize all application role names for authorization and identity management.

**Secure configuration and user secrets:**

* Updated `src/Beagl.WebApp/Beagl.WebApp.csproj` to include a `UserSecretsId`, enabling the use of `dotnet user-secrets` for development credentials.
* Added documentation in `README.md` describing how to use user secrets to securely provide default admin credentials for seeding.

**Other improvements:**

* Ensured the application awaits `RunAsync` for proper async shutdown in `src/Beagl.WebApp/Program.cs`.
* Minor update to `.editorconfig` to disable a code analysis rule.