### PR TITLE
Feature/complete listing and creation of citizens

### DIFF
--- a/src/Beagl.Application/CitizenManagement/DTOs/CitizenListDto.cs
+++ b/src/Beagl.Application/CitizenManagement/DTOs/CitizenListDto.cs
@@ -22,14 +22,19 @@ public class CitizenListDto
     public required string Name { get; init; }
 
     /// <summary>
-    /// Gets the phone numbers of the citizen.
+	/// Phone number.
+	/// </summary>
+	public string? Phone { get; set; }
+
+    /// <summary>
+    /// Cell phone number.
     /// </summary>
-    public Collection<string> PhoneNumbers { get; init; } = [];
+    public string? CellPhone { get; set; }
 
     /// <summary>
     /// Gets the email address of the citizen.
     /// </summary>
-    public string Email { get; init; } = string.Empty;
+    public string? Email { get; init; } = string.Empty;
 
     /// <summary>
     /// Gets the number of animals associated with the citizen.

--- a/src/Beagl.Application/CitizenManagement/DTOs/CreateCitizenDto.cs
+++ b/src/Beagl.Application/CitizenManagement/DTOs/CreateCitizenDto.cs
@@ -10,17 +10,17 @@ public class CreateCitizenDto
     /// <summary>
 	/// Civility (e.g., Mr., Mrs., Ms., etc.)
 	/// </summary>
-	public string? Civility { get; set; }
+	public int Civility { get; set; } = default!;
 
 	/// <summary>
 	/// First name of the citizen.
 	/// </summary>
-	public string? FirstName { get; set; }
+	public string FirstName { get; set; } = default!;
 
 	/// <summary>
 	/// Last name of the citizen.
 	/// </summary>
-	public string? LastName { get; set; }
+	public string LastName { get; set; } = default!;
 
 	/// <summary>
 	/// Phone number.
@@ -35,12 +35,12 @@ public class CreateCitizenDto
 	/// <summary>
 	/// Communication preference (Phone, CellPhone, Email).
 	/// </summary>
-    public string? CommunicationPreference { get; set; }
+    public int CommunicationPreference { get; set; } = default!;
 
 	/// <summary>
 	/// Language preference (fr, en).
 	/// </summary>
-    public string? LanguagePreference { get; set; }
+    public int LanguagePreference { get; set; } = default!;
 
 	/// <summary>
 	/// Email address.
@@ -50,12 +50,12 @@ public class CreateCitizenDto
     /// <summary>
 	/// Street number.
 	/// </summary>
-    public string? StreetNumber { get; set; }
+    public string StreetNumber { get; set; } = default!;
 
 	/// <summary>
 	/// Street name.
 	/// </summary>
-	public string? StreetName { get; set; }
+	public string StreetName { get; set; } = default!;
 
 	/// <summary>
 	/// Apartment number.
@@ -65,22 +65,22 @@ public class CreateCitizenDto
 	/// <summary>
 	/// City.
 	/// </summary>
-    public string? City { get; set; }
+    public string City { get; set; } = default!;
 
 	/// <summary>
 	/// Province.
 	/// </summary>
-    public string? Province { get; set; }
+    public string Province { get; set; } = default!;
 
 	/// <summary>
 	/// Country.
 	/// </summary>
-    public string? Country { get; set; }
+    public string Country { get; set; } = default!;
 
 	/// <summary>
 	/// Postal code.
 	/// </summary>
-	public string? PostalCode { get; set; }
+	public string PostalCode { get; set; } = default!;
 
 	/// <summary>
 	/// Post office box.

--- a/src/Beagl.Application/CitizenManagement/DTOs/CreateCitizenDto.cs
+++ b/src/Beagl.Application/CitizenManagement/DTOs/CreateCitizenDto.cs
@@ -1,0 +1,89 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+namespace Beagl.Application.CitizenManagement.DTOs;
+
+/// <summary>
+/// Data transfer object for creating a new citizen.
+/// </summary>
+public class CreateCitizenDto
+{
+    /// <summary>
+	/// Civility (e.g., Mr., Mrs., Ms., etc.)
+	/// </summary>
+	public string? Civility { get; set; }
+
+	/// <summary>
+	/// First name of the citizen.
+	/// </summary>
+	public string? FirstName { get; set; }
+
+	/// <summary>
+	/// Last name of the citizen.
+	/// </summary>
+	public string? LastName { get; set; }
+
+	/// <summary>
+	/// Phone number.
+	/// </summary>
+	public string? Phone { get; set; }
+
+    /// <summary>
+    /// Cell phone number.
+    /// </summary>
+    public string? CellPhone { get; set; }
+
+	/// <summary>
+	/// Communication preference (Phone, CellPhone, Email).
+	/// </summary>
+    public string? CommunicationPreference { get; set; }
+
+	/// <summary>
+	/// Language preference (fr, en).
+	/// </summary>
+    public string? LanguagePreference { get; set; }
+
+	/// <summary>
+	/// Email address.
+	/// </summary>
+	public string? Email { get; set; }
+
+    /// <summary>
+	/// Street number.
+	/// </summary>
+    public string? StreetNumber { get; set; }
+
+	/// <summary>
+	/// Street name.
+	/// </summary>
+	public string? StreetName { get; set; }
+
+	/// <summary>
+	/// Apartment number.
+	/// </summary>
+    public string? Appartment { get; set; }
+
+	/// <summary>
+	/// City.
+	/// </summary>
+    public string? City { get; set; }
+
+	/// <summary>
+	/// Province.
+	/// </summary>
+    public string? Province { get; set; }
+
+	/// <summary>
+	/// Country.
+	/// </summary>
+    public string? Country { get; set; }
+
+	/// <summary>
+	/// Postal code.
+	/// </summary>
+	public string? PostalCode { get; set; }
+
+	/// <summary>
+	/// Post office box.
+	/// </summary>
+	public string? PostOfficeBox { get; set; }
+}

--- a/src/Beagl.Application/CitizenManagement/Services/ICitizenService.cs
+++ b/src/Beagl.Application/CitizenManagement/Services/ICitizenService.cs
@@ -1,0 +1,20 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using System;
+using System.Threading.Tasks;
+using Beagl.Application.CitizenManagement.DTOs;
+
+namespace Beagl.Application.CitizenManagement.Services;
+
+/// <summary>
+/// Service interface for managing citizens.
+/// </summary>
+public interface ICitizenService
+{
+    /// <summary>
+    /// Creates a new citizen in the system.
+    /// </summary>
+    /// <param name="createCitizenDto">The data transfer object containing citizen creation details.</param>
+    /// <returns>The unique identifier of the newly created citizen.</returns>
+    public Task<Guid> CreateAsync(CreateCitizenDto createCitizenDto);
+}

--- a/src/Beagl.Application/Core/Helpers/EnumHelper.cs
+++ b/src/Beagl.Application/Core/Helpers/EnumHelper.cs
@@ -1,0 +1,21 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using System;
+
+namespace Beagl.Application.Core.Helpers;
+
+/// <summary>
+/// Helper methods for enum conversions.
+/// </summary>
+public static class EnumHelper
+{
+    /// <summary>
+    /// Converts an integer to a specified enum type.
+    /// </summary>
+    public static TEnum FromInt<TEnum>(int value) where TEnum : Enum
+    {
+        if (!Enum.IsDefined(typeof(TEnum), value))
+            throw new ArgumentException("Invalid enum value.", nameof(value));
+        return (TEnum)(object)value;
+    }
+}

--- a/src/Beagl.Domain/CitizenManagement/Entities/Address.cs
+++ b/src/Beagl.Domain/CitizenManagement/Entities/Address.cs
@@ -72,7 +72,7 @@ public sealed class Address
     /// <summary>
     /// Parameterless constructor for EF Core.
     /// </summary>
-    public Address() { }
+    private Address() { }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Address"/> class.

--- a/src/Beagl.Domain/CitizenManagement/Entities/Address.cs
+++ b/src/Beagl.Domain/CitizenManagement/Entities/Address.cs
@@ -1,0 +1,101 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using System;
+
+namespace Beagl.Domain.CitizenManagement.Entities;
+
+/// <summary>
+/// Represents a postal address for a citizen, including metadata for ordering.
+/// </summary>
+public sealed class Address
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for the address.
+    /// </summary>
+    public Guid AddressId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the street number.
+    /// </summary>
+    public string StreetNumber { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the street name.
+    /// </summary>
+    public string StreetName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the apartment number.
+    /// </summary>
+    public string? Appartment { get; set; }
+
+    /// <summary>
+    /// Gets or sets the city.
+    /// </summary>
+    public string City { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the province.
+    /// </summary>
+    public string Province { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the country.
+    /// </summary>
+    public string Country { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the postal code.
+    /// </summary>
+    public string PostalCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the post office box.
+    /// </summary>
+    public string? PostOfficeBox { get; set; }
+
+    /// <summary>
+    /// Gets or sets the date the address was added (used for ordering).
+    /// </summary>
+    public DateTime AddedDate { get; set; } = DateTime.UtcNow.ToUniversalTime();
+
+    /// <summary>
+    /// Gets or sets the citizen id (foreign key).
+    /// </summary>
+    public Guid CitizenId { get; set; }
+
+    /// <summary>
+    /// Navigation property to the owning citizen.
+    /// </summary>
+    public Citizen? Citizen { get; set; }
+
+    /// <summary>
+    /// Parameterless constructor for EF Core.
+    /// </summary>
+    public Address() { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Address"/> class.
+    /// </summary>
+    public Address(
+        string streetNumber,
+        string streetName,
+        string? appartment,
+        string city,
+        string province,
+        string country,
+        string postalCode,
+        string? postOfficeBox)
+    {
+        AddressId = Guid.NewGuid();
+        StreetNumber = streetNumber;
+        StreetName = streetName;
+        Appartment = appartment;
+        City = city;
+        Province = province;
+        Country = country;
+        PostalCode = postalCode;
+        PostOfficeBox = postOfficeBox;
+        AddedDate = DateTime.UtcNow.ToUniversalTime();
+    }
+}

--- a/src/Beagl.Domain/CitizenManagement/Entities/Citizen.cs
+++ b/src/Beagl.Domain/CitizenManagement/Entities/Citizen.cs
@@ -13,6 +13,43 @@ namespace Beagl.Domain.CitizenManagement.Entities;
 public class Citizen
 {
     /// <summary>
+    /// Private parameterless constructor for EF Core.
+    /// </summary>
+    private Citizen() { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Citizen"/> class.
+    /// </summary>
+    /// <param name="person">The name of the citizen.</param>
+    /// <param name="phone">The phone number.</param>
+    /// <param name="cellPhone">The cell phone number.</param>
+    /// <param name="communicationPreference">The communication preference.</param>
+    /// <param name="languagePreference">The language preference.</param>
+    /// <param name="email">The email address.</param>
+    /// <param name="address">The address.</param>
+    /// <param name="created">The audit information for creation.</param>
+    public Citizen(
+        PersonName person,
+        string? phone,
+        string? cellPhone,
+        CommunicationPreference communicationPreference,
+        LanguagePreference languagePreference,
+        string? email,
+        Address address,
+        Audit<Guid> created)
+    {
+        Id = Guid.NewGuid();
+        Person = person;
+        Phone = phone;
+        CellPhone = cellPhone;
+        CommunicationPreference = communicationPreference;
+        LanguagePreference = languagePreference;
+        Email = email;
+        Addresses = [address];
+        Created = created;
+    }
+
+    /// <summary>
     /// Gets or sets the unique identifier for the citizen.
     /// </summary>
     public Guid Id { get; set; }
@@ -23,9 +60,9 @@ public class Citizen
     public PersonName Person { get; set; } = default!;
 
     /// <summary>
-	/// Gets or sets the phone number.
-	/// </summary>
-	public string? Phone { get; set; }
+    /// Gets or sets the phone number.
+    /// </summary>
+    public string? Phone { get; set; }
 
     /// <summary>
     /// Gets or sets the cell phone number.
@@ -33,8 +70,8 @@ public class Citizen
     public string? CellPhone { get; set; }
 
     /// <summary>
-	/// Gets or sets the communication preference (Phone, CellPhone, Email).
-	/// </summary>
+    /// Gets or sets the communication preference (Phone, CellPhone, Email).
+    /// </summary>
     public CommunicationPreference CommunicationPreference { get; set; } = CommunicationPreference.None;
 
     /// <summary>
@@ -43,12 +80,12 @@ public class Citizen
     public LanguagePreference LanguagePreference { get; set; } = LanguagePreference.None;
 
     /// <summary>
-	/// Gets or sets the email address.
-	/// </summary>
-	public string? Email { get; set; }
+    /// Gets or sets the email address.
+    /// </summary>
+    public string? Email { get; set; }
 
     /// <summary>
-    /// Gets or sets the list of addresses associated with the citizen.
+    /// Gets the list of addresses associated with the citizen.
     /// </summary>
     public ICollection<Address> Addresses { get; } = [];
 

--- a/src/Beagl.Domain/CitizenManagement/Entities/Citizen.cs
+++ b/src/Beagl.Domain/CitizenManagement/Entities/Citizen.cs
@@ -1,0 +1,64 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using System;
+using System.Collections.Generic;
+using Beagl.Domain.CitizenManagement.ValueObjects;
+using Beagl.Domain.Core.ValueObjects;
+
+namespace Beagl.Domain.CitizenManagement.Entities;
+
+/// <summary>
+/// Persistence model for Citizen aggregate.
+/// </summary>
+public class Citizen
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for the citizen.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the citizen.
+    /// </summary>
+    public PersonName Person { get; set; } = default!;
+
+    /// <summary>
+	/// Gets or sets the phone number.
+	/// </summary>
+	public string? Phone { get; set; }
+
+    /// <summary>
+    /// Gets or sets the cell phone number.
+    /// </summary>
+    public string? CellPhone { get; set; }
+
+    /// <summary>
+	/// Gets or sets the communication preference (Phone, CellPhone, Email).
+	/// </summary>
+    public CommunicationPreference CommunicationPreference { get; set; } = CommunicationPreference.None;
+
+    /// <summary>
+    /// Gets or sets the language preference (fr, en).
+    /// </summary>
+    public LanguagePreference LanguagePreference { get; set; } = LanguagePreference.None;
+
+    /// <summary>
+	/// Gets or sets the email address.
+	/// </summary>
+	public string? Email { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of addresses associated with the citizen.
+    /// </summary>
+    public ICollection<Address> Addresses { get; } = [];
+
+    /// <summary>
+    /// Gets the audit information for creation.
+    /// </summary>
+    public Audit<Guid> Created { get; set; } = new Audit<Guid>(Guid.Empty, DateTimeOffset.MinValue);
+
+    /// <summary>
+    /// Gets the audit information for last modification.
+    /// </summary>
+    public Audit<Guid>? Modified { get; set; } = new Audit<Guid>(Guid.Empty, DateTimeOffset.MinValue);
+}

--- a/src/Beagl.Domain/CitizenManagement/Repositories/ICitizenRepository.cs
+++ b/src/Beagl.Domain/CitizenManagement/Repositories/ICitizenRepository.cs
@@ -1,0 +1,18 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using System;
+using System.Threading.Tasks;
+using Beagl.Domain.CitizenManagement.Entities;
+
+namespace Beagl.Domain.CitizenManagement.Repositories;
+
+/// <summary>
+/// Repository interface for managing Citizen entities.
+/// </summary>
+public interface ICitizenRepository
+{
+    /// <summary>
+    /// Asynchronously creates a new Citizen entity in the data store.
+    /// </summary>
+    public Task<Guid> CreateAsync(Citizen citizen);
+}

--- a/src/Beagl.Domain/CitizenManagement/ValueObjects/Civility.cs
+++ b/src/Beagl.Domain/CitizenManagement/ValueObjects/Civility.cs
@@ -1,0 +1,44 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+namespace Beagl.Domain.CitizenManagement.ValueObjects;
+
+/// <summary>
+/// Represents the civility (title) of a person.
+/// </summary>
+public enum Civility
+{
+    /// <summary>
+    /// No civility specified.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Mister
+    /// </summary>
+    Mr = 1,
+
+    /// <summary>
+    /// Misses
+    /// </summary>
+    Mrs = 2,
+
+    /// <summary>
+    /// Miss
+    /// </summary>
+    Ms = 3,
+
+    /// <summary>
+    /// Mx (gender-neutral)
+    /// </summary>
+    Mx = 4,
+
+    /// <summary>
+    /// Doctor
+    /// </summary>
+    Dr = 5,
+
+    /// <summary>
+    /// Professor
+    /// </summary>
+    Prof = 6
+}

--- a/src/Beagl.Domain/CitizenManagement/ValueObjects/CommunicationPreference.cs
+++ b/src/Beagl.Domain/CitizenManagement/ValueObjects/CommunicationPreference.cs
@@ -1,0 +1,29 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+namespace Beagl.Domain.CitizenManagement.ValueObjects;
+
+/// <summary>
+/// Represents the communication preference of a citizen.
+/// </summary>
+public enum CommunicationPreference
+{
+    /// <summary>
+    /// No communication preference specified.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Prefer communication via phone.
+    /// </summary>
+    Phone = 1,
+
+    /// <summary>
+    /// Prefer communication via cell phone.
+    /// </summary>
+    CellPhone = 2,
+
+    /// <summary>
+    /// Prefer communication via email.
+    /// </summary>
+    Email = 3
+}

--- a/src/Beagl.Domain/CitizenManagement/ValueObjects/LanguagePreference.cs
+++ b/src/Beagl.Domain/CitizenManagement/ValueObjects/LanguagePreference.cs
@@ -1,0 +1,24 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+namespace Beagl.Domain.CitizenManagement.ValueObjects;
+
+/// <summary>
+/// Represents the language preference of a citizen.
+/// </summary>
+public enum LanguagePreference
+{
+    /// <summary>
+    /// No language preference specified.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// French language preference.
+    /// </summary>
+    French = 1,
+
+    /// <summary>
+    /// English language preference.
+    /// </summary>
+    English = 2
+}

--- a/src/Beagl.Domain/CitizenManagement/ValueObjects/PersonName.cs
+++ b/src/Beagl.Domain/CitizenManagement/ValueObjects/PersonName.cs
@@ -1,0 +1,24 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+namespace Beagl.Domain.CitizenManagement.ValueObjects;
+
+/// <summary>
+/// Represents a person's name.
+/// </summary>
+public class PersonName
+{
+    /// <summary>
+    /// Gets or sets the civility (title) of the person.
+    /// </summary>
+    public Civility Civility { get; set; }
+
+    /// <summary>
+    /// Gets or sets the first name.
+    /// </summary>
+    public required string FirstName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the last name.
+    /// </summary>
+    public required string LastName { get; set; }
+}

--- a/src/Beagl.Domain/CitizenManagement/ValueObjects/PersonName.cs
+++ b/src/Beagl.Domain/CitizenManagement/ValueObjects/PersonName.cs
@@ -5,20 +5,24 @@ namespace Beagl.Domain.CitizenManagement.ValueObjects;
 /// <summary>
 /// Represents a person's name.
 /// </summary>
-public class PersonName
+/// <remarks>
+/// Initializes a new instance of the <see cref="PersonName"/> class.
+/// </remarks>
+public class PersonName(Civility civility, string firstName, string lastName)
 {
+
     /// <summary>
     /// Gets or sets the civility (title) of the person.
     /// </summary>
-    public Civility Civility { get; set; }
+    public Civility Civility { get; set; } = civility;
 
     /// <summary>
     /// Gets or sets the first name.
     /// </summary>
-    public required string FirstName { get; set; }
+    public string FirstName { get; set; } = firstName;
 
     /// <summary>
     /// Gets or sets the last name.
     /// </summary>
-    public required string LastName { get; set; }
+    public string LastName { get; set; } = lastName;
 }

--- a/src/Beagl.Infrastructure/ApplicationDbContext.cs
+++ b/src/Beagl.Infrastructure/ApplicationDbContext.cs
@@ -4,6 +4,9 @@ using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Beagl.Infrastructure.UserManagement.Entities;
 using Beagl.Domain.AnimalManagement.Entities;
+using Beagl.Domain.CitizenManagement.Entities;
+using Beagl.Domain.CitizenManagement.ValueObjects;
+using Beagl.Domain.Core.ValueObjects;
 
 namespace Beagl.Infrastructure;
 
@@ -39,6 +42,16 @@ public class ApplicationDbContext(
     /// Gets or sets the Breeds table.
     /// </summary>
     public DbSet<Breed> Breeds { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the Citizens table.
+    /// </summary>
+    public DbSet<Citizen> Citizens { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the Addresses table.
+    /// </summary>
+    public DbSet<Address> Addresses { get; set; } = null!;
 
     /// <summary>
     /// Configures the model for Animal, HealthRecord, and complex types.
@@ -87,6 +100,53 @@ public class ApplicationDbContext(
                 a.Property(p => p.UserId).HasColumnName("ModifiedByUserId");
                 a.Property(p => p.At).HasColumnName("ModifiedAt");
             });
+        });
+
+        // Configure Citizen entity
+        builder.Entity<Citizen>(entity =>
+        {
+            entity.ToTable("Citizens");
+            entity.HasKey(c => c.Id);
+
+            // PersonName as owned type
+            entity.OwnsOne(c => c.Person, pn =>
+            {
+                pn.Property(p => p.Civility).HasColumnName("Civility");
+                pn.Property(p => p.FirstName).HasColumnName("FirstName");
+                pn.Property(p => p.LastName).HasColumnName("LastName");
+            });
+
+            // Audit as owned types
+            entity.OwnsOne(c => c.Created, a =>
+            {
+                a.Property(p => p.UserId).HasColumnName("CreatedByUserId");
+                a.Property(p => p.At).HasColumnName("CreatedAt");
+            });
+            entity.OwnsOne(c => c.Modified, a =>
+            {
+                a.Property(p => p.UserId).HasColumnName("ModifiedByUserId");
+                a.Property(p => p.At).HasColumnName("ModifiedAt");
+            });
+
+            // One-to-many: Citizen - Addresses
+            entity.HasMany(c => c.Addresses)
+                .WithOne(a => a.Citizen)
+                .HasForeignKey(a => a.CitizenId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // Configure Address entity
+        builder.Entity<Address>(entity =>
+        {
+            entity.ToTable("Addresses");
+            entity.HasKey(a => a.AddressId);
+            entity.Property(a => a.StreetNumber).IsRequired();
+            entity.Property(a => a.StreetName).IsRequired();
+            entity.Property(a => a.City).IsRequired();
+            entity.Property(a => a.Province).IsRequired();
+            entity.Property(a => a.Country).IsRequired();
+            entity.Property(a => a.PostalCode).IsRequired();
+            entity.Property(a => a.AddedDate).IsRequired();
         });
 
         // Configure TPT inheritance for Dog

--- a/src/Beagl.Infrastructure/CitizenManagement/Repositories/CitizenRepository.cs
+++ b/src/Beagl.Infrastructure/CitizenManagement/Repositories/CitizenRepository.cs
@@ -1,0 +1,23 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using Beagl.Domain.CitizenManagement.Entities;
+using Beagl.Domain.CitizenManagement.Repositories;
+
+namespace Beagl.Infrastructure.CitizenManagement.Repositories;
+
+/// <summary>
+/// Repository implementation for managing Citizen entities.
+/// </summary>
+public class CitizenRepository(
+    ApplicationDbContext dbContext) : ICitizenRepository
+{
+    /// <inheritdoc/>
+    public async Task<Guid> CreateAsync(Citizen citizen)
+    {
+        ArgumentNullException.ThrowIfNull(citizen);
+
+        dbContext.Citizens.Add(citizen);
+        await dbContext.SaveChangesAsync();
+        return citizen.Id;
+    }
+}

--- a/src/Beagl.Infrastructure/CitizenManagement/Services/CitizenQueryService.cs
+++ b/src/Beagl.Infrastructure/CitizenManagement/Services/CitizenQueryService.cs
@@ -1,10 +1,8 @@
 // MIT License - Copyright (c) 2025 Jonathan St-Michel
 
-using System.Collections.ObjectModel;
 using Beagl.Application.CitizenManagement.DTOs;
 using Beagl.Application.CitizenManagement.Services;
-using Beagl.Domain.AnimalManagement.Entities;
-using Beagl.Domain.AnimalManagement.ValueObjects;
+using Beagl.Domain.CitizenManagement.Entities;
 using Microsoft.EntityFrameworkCore;
 
 namespace Beagl.Infrastructure.CitizenManagement.Services;
@@ -12,43 +10,33 @@ namespace Beagl.Infrastructure.CitizenManagement.Services;
 /// <summary>
 /// Concrete implementation of ICitizenQueryService for querying paginated citizen list DTOs.
 /// </summary>
-public sealed class CitizenQueryService : ICitizenQueryService
+public sealed class CitizenQueryService
+    (ApplicationDbContext dbContext) : ICitizenQueryService
 {
     /// <inheritdoc/>
     public async Task<(IList<CitizenListDto> Items, int TotalCount)> GetPagedAsync(CitizenPagedFilterDto filter)
     {
         ArgumentNullException.ThrowIfNull(filter);
 
-        // IQueryable<Citizen> query = dbContext.Citizens;
-        // int totalCount = await query.CountAsync();
+        IQueryable<Citizen> query = dbContext.Citizens;
+        int totalCount = await query.CountAsync();
 
-        // IQueryable<AnimalListDto> projected = query
-        //     .Select(a => new AnimalListDto
-        //     {
-        //         Id = a.Id,
-        //         Name = a.Name,
-        //         Breed = a.PrimaryBreed != null ? a.PrimaryBreed.Name : string.Empty,
-        //         Color = a.Color != null ? a.Color.Name : string.Empty,
-        //         BirthDate = a.DateOfBirth,
-        //         MicrochipNumber = a.Microchip != null ? a.Microchip.Value : null,
-        //         Species = a.SpeciesType,
-        //         Gender = a.Gender,
-        //     });
+        IQueryable<CitizenListDto> projected = query
+            .Select(a => new CitizenListDto
+            {
+                Id = a.Id,
+                Name = a.Person.FirstName,
+                Phone = a.Phone,
+                CellPhone = a.CellPhone,
+                Email = a.Email,
+                AnimalsCount = 0,
+            });
 
-        // IList<AnimalListDto> items = await projected
-        //     .Skip((filter.PageNumber - 1) * filter.PageSize)
-        //     .Take(filter.PageSize)
-        //     .ToListAsync();
+        IList<CitizenListDto> items = await projected
+            .Skip((filter.PageNumber - 1) * filter.PageSize)
+            .Take(filter.PageSize)
+            .ToListAsync();
 
-        // return (items, totalCount);
-
-        return await Task.FromResult((new List<CitizenListDto> { new CitizenListDto
-        {
-            Id = Guid.NewGuid(),
-            Name = "John Doe",
-            PhoneNumbers = ["123-456-7890"],
-            Email = "john.doe@example.com",
-            AnimalsCount = 2
-        } }, 0));
+        return (items, totalCount);
     }
 }

--- a/src/Beagl.Infrastructure/CitizenManagement/Services/CitizenService.cs
+++ b/src/Beagl.Infrastructure/CitizenManagement/Services/CitizenService.cs
@@ -2,6 +2,11 @@
 
 using Beagl.Application.CitizenManagement.DTOs;
 using Beagl.Application.CitizenManagement.Services;
+using Beagl.Application.Core.Helpers;
+using Beagl.Domain.CitizenManagement.Entities;
+using Beagl.Domain.CitizenManagement.Repositories;
+using Beagl.Domain.CitizenManagement.ValueObjects;
+using Beagl.Domain.Core.ValueObjects;
 
 namespace Beagl.Infrastructure.CitizenManagement.Services;
 
@@ -9,12 +14,37 @@ namespace Beagl.Infrastructure.CitizenManagement.Services;
 /// Implementation of the citizen service.
 /// </summary>
 /// <seealso cref="Beagl.Application.CitizenManagement.Services.ICitizenService"/>
-public class CitizenService : ICitizenService
+public class CitizenService(
+    ICitizenRepository citizenRepository) : ICitizenService
 {
     /// <inheritdoc/>
-    public Task<Guid> CreateAsync(CreateCitizenDto createCitizenDto)
+    public async Task<Guid> CreateAsync(CreateCitizenDto createCitizenDto)
     {
-        // Implementation for creating a citizen goes here.
-        throw new NotImplementedException();
+        ArgumentNullException.ThrowIfNull(createCitizenDto);
+
+        Citizen newCitizen = new(
+            new PersonName(
+                EnumHelper.FromInt<Civility>(createCitizenDto.Civility),
+                createCitizenDto.FirstName,
+                createCitizenDto.LastName),
+            createCitizenDto.Phone,
+            createCitizenDto.CellPhone,
+            EnumHelper.FromInt<CommunicationPreference>(createCitizenDto.CommunicationPreference),
+            EnumHelper.FromInt<LanguagePreference>(createCitizenDto.LanguagePreference),
+            createCitizenDto.Email,
+            new Address(
+                createCitizenDto.StreetNumber,
+                createCitizenDto.StreetName,
+                createCitizenDto.Appartment,
+                createCitizenDto.City,
+                createCitizenDto.Province,
+                createCitizenDto.Country,
+                createCitizenDto.PostalCode,
+                createCitizenDto.PostOfficeBox
+            ),
+            Audit.From(Guid.Empty, DateTimeOffset.UtcNow.ToUniversalTime()));
+
+        Guid citizenId = await citizenRepository.CreateAsync(newCitizen);
+        return citizenId;
     }
 }

--- a/src/Beagl.Infrastructure/CitizenManagement/Services/CitizenService.cs
+++ b/src/Beagl.Infrastructure/CitizenManagement/Services/CitizenService.cs
@@ -1,0 +1,20 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using Beagl.Application.CitizenManagement.DTOs;
+using Beagl.Application.CitizenManagement.Services;
+
+namespace Beagl.Infrastructure.CitizenManagement.Services;
+
+/// <summary>
+/// Implementation of the citizen service.
+/// </summary>
+/// <seealso cref="Beagl.Application.CitizenManagement.Services.ICitizenService"/>
+public class CitizenService : ICitizenService
+{
+    /// <inheritdoc/>
+    public Task<Guid> CreateAsync(CreateCitizenDto createCitizenDto)
+    {
+        // Implementation for creating a citizen goes here.
+        throw new NotImplementedException();
+    }
+}

--- a/src/Beagl.Infrastructure/Core/Extensions/ServiceCollectionInfrastructureExtensions.cs
+++ b/src/Beagl.Infrastructure/Core/Extensions/ServiceCollectionInfrastructureExtensions.cs
@@ -3,8 +3,10 @@
 using Beagl.Application.AnimalManagement.Services;
 using Beagl.Application.CitizenManagement.Services;
 using Beagl.Domain.AnimalManagement.Repositories;
+using Beagl.Domain.CitizenManagement.Repositories;
 using Beagl.Infrastructure.AnimalManagement.Repositories;
 using Beagl.Infrastructure.AnimalManagement.Services;
+using Beagl.Infrastructure.CitizenManagement.Repositories;
 using Beagl.Infrastructure.CitizenManagement.Services;
 using Beagl.Infrastructure.UserManagement.Interfaces;
 using Beagl.Infrastructure.UserManagement.Services;
@@ -72,6 +74,7 @@ public static class ServiceCollectionInfrastructureExtensions
     {
         services.AddScoped<ICatRepository, CatRepository>();
         services.AddScoped<IDogRepository, DogRepository>();
+        services.AddScoped<ICitizenRepository, CitizenRepository>();
         return services;
     }
 }

--- a/src/Beagl.Infrastructure/Core/Extensions/ServiceCollectionInfrastructureExtensions.cs
+++ b/src/Beagl.Infrastructure/Core/Extensions/ServiceCollectionInfrastructureExtensions.cs
@@ -1,9 +1,11 @@
 // MIT License - Copyright (c) 2025 Jonathan St-Michel
 
 using Beagl.Application.AnimalManagement.Services;
+using Beagl.Application.CitizenManagement.Services;
 using Beagl.Domain.AnimalManagement.Repositories;
 using Beagl.Infrastructure.AnimalManagement.Repositories;
 using Beagl.Infrastructure.AnimalManagement.Services;
+using Beagl.Infrastructure.CitizenManagement.Services;
 using Beagl.Infrastructure.UserManagement.Interfaces;
 using Beagl.Infrastructure.UserManagement.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -57,6 +59,7 @@ public static class ServiceCollectionInfrastructureExtensions
     {
         services.AddScoped<ICatService, CatService>();
         services.AddScoped<IDogService, DogService>();
+        services.AddScoped<ICitizenService, CitizenService>();
         return services;
     }
 

--- a/src/Beagl.Infrastructure/Migrations/20251028003052_AddCitizenAndAddress.Designer.cs
+++ b/src/Beagl.Infrastructure/Migrations/20251028003052_AddCitizenAndAddress.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Beagl.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Beagl.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251028003052_AddCitizenAndAddress")]
+    partial class AddCitizenAndAddress
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Beagl.Infrastructure/Migrations/20251028003052_AddCitizenAndAddress.cs
+++ b/src/Beagl.Infrastructure/Migrations/20251028003052_AddCitizenAndAddress.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Beagl.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCitizenAndAddress : Migration
+    {
+        /// <inheritdoc />
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "<Pending>")]
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Citizens",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Civility = table.Column<int>(type: "integer", nullable: false),
+                    FirstName = table.Column<string>(type: "text", nullable: false),
+                    LastName = table.Column<string>(type: "text", nullable: false),
+                    Phone = table.Column<string>(type: "text", nullable: true),
+                    CellPhone = table.Column<string>(type: "text", nullable: true),
+                    CommunicationPreference = table.Column<int>(type: "integer", nullable: false),
+                    LanguagePreference = table.Column<int>(type: "integer", nullable: false),
+                    Email = table.Column<string>(type: "text", nullable: true),
+                    CreatedByUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ModifiedByUserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    ModifiedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Citizens", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Addresses",
+                columns: table => new
+                {
+                    AddressId = table.Column<Guid>(type: "uuid", nullable: false),
+                    StreetNumber = table.Column<string>(type: "text", nullable: false),
+                    StreetName = table.Column<string>(type: "text", nullable: false),
+                    Appartment = table.Column<string>(type: "text", nullable: true),
+                    City = table.Column<string>(type: "text", nullable: false),
+                    Province = table.Column<string>(type: "text", nullable: false),
+                    Country = table.Column<string>(type: "text", nullable: false),
+                    PostalCode = table.Column<string>(type: "text", nullable: false),
+                    PostOfficeBox = table.Column<string>(type: "text", nullable: true),
+                    AddedDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CitizenId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Addresses", x => x.AddressId);
+                    table.ForeignKey(
+                        name: "FK_Addresses_Citizens_CitizenId",
+                        column: x => x.CitizenId,
+                        principalTable: "Citizens",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Addresses_CitizenId",
+                table: "Addresses",
+                column: "CitizenId");
+        }
+
+        /// <inheritdoc />
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "<Pending>")]
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Addresses");
+
+            migrationBuilder.DropTable(
+                name: "Citizens");
+        }
+    }
+}

--- a/src/Beagl.WebApp/Pages/Citizens/Create.cshtml
+++ b/src/Beagl.WebApp/Pages/Citizens/Create.cshtml
@@ -38,13 +38,13 @@
                                     <label class="form-label">@Localizer["Name"]</label>
                                     <div class="input-group mb-3">
                                         <select class="form-select" style="max-width: 140px;" asp-for="Input.Civility">
-                                            <option value="">@Localizer["Civility"]</option>
-                                            <option value="Mr">@Localizer["Mr."]</option>
-                                            <option value="Mrs">@Localizer["Mrs."]</option>
-                                            <option value="Ms">@Localizer["Ms."]</option>
-                                            <option value="Mx">@Localizer["Mx."]</option>
-                                            <option value="Dr">@Localizer["Dr."]</option>
-                                            <option value="Prof">@Localizer["Prof."]</option>
+                                            <option value="0">@Localizer["Civility"]</option>
+                                            <option value="1">@Localizer["Mr."]</option>
+                                            <option value="2">@Localizer["Mrs."]</option>
+                                            <option value="3">@Localizer["Ms."]</option>
+                                            <option value="4">@Localizer["Mx."]</option>
+                                            <option value="5">@Localizer["Dr."]</option>
+                                            <option value="6">@Localizer["Prof."]</option>
                                         </select>
                                         <input type="text" class="form-control" aria-label="First name" placeholder="@Localizer["First Name"]" asp-for="Input.FirstName">
                                         <input type="text" class="form-control" aria-label="Last name" placeholder="@Localizer["Last Name"]" asp-for="Input.LastName">
@@ -82,18 +82,18 @@
                                 <div class="mb-3">
                                     <label class="form-label" for="CommunicationPreference">@Localizer["Communication Preference"]</label>
                                     <select class="form-select" id="CommunicationPreference" asp-for="Input.CommunicationPreference">
-                                        <option value="">@Localizer["Select Preference"]</option>
-                                        <option value="Phone">@Localizer["Phone"]</option>
-                                        <option value="CellPhone">@Localizer["Cell Phone"]</option>
-                                        <option value="Email">@Localizer["Email"]</option>
+                                        <option value="0">@Localizer["Select Preference"]</option>
+                                        <option value="1">@Localizer["Phone"]</option>
+                                        <option value="2">@Localizer["Cell Phone"]</option>
+                                        <option value="3">@Localizer["Email"]</option>
                                     </select>
                                 </div>
                                 <div class="mb-3">
                                     <label class="form-label" for="LanguagePreference">@Localizer["Language Preference"]</label>
                                     <select class="form-select" id="LanguagePreference" asp-for="Input.LanguagePreference">
-                                        <option value="">@Localizer["Select Language"]</option>
-                                        <option value="fr">@Localizer["French"]</option>
-                                        <option value="en">@Localizer["English"]</option>
+                                        <option value="0">@Localizer["Select Language"]</option>
+                                        <option value="1">@Localizer["French"]</option>
+                                        <option value="2">@Localizer["English"]</option>
                                     </select>
                                 </div>
                             </div>

--- a/src/Beagl.WebApp/Pages/Citizens/Create.cshtml.cs
+++ b/src/Beagl.WebApp/Pages/Citizens/Create.cshtml.cs
@@ -1,3 +1,5 @@
+using Beagl.Application.CitizenManagement.DTOs;
+using Beagl.Application.CitizenManagement.Services;
 using Beagl.WebApp.Constants;
 using Beagl.WebApp.Pages.Citizens.ViewModels;
 using Microsoft.AspNetCore.Mvc;
@@ -8,7 +10,8 @@ namespace Beagl.WebApp.Pages.Citizens;
 /// <summary>
 /// Page model for creating a new citizen.
 /// </summary>
-internal sealed class CreateCitizenModel : PageModel
+internal sealed class CreateCitizenModel(
+    ICitizenService citizenService) : PageModel
 {
     /// <summary>
     /// Gets or sets the input model for creating a citizen.
@@ -25,21 +28,33 @@ internal sealed class CreateCitizenModel : PageModel
             return Page();
         }
 
-        // _ = await catService.CreateCatAsync(new CreateCatDto
-        // {
-        //     Name = Input.Name,
-        //     BreedPrimaryId = Input.BreedPrimaryId!.Value,
-        //     ColorId = Input.ColorId!.Value,
-        //     Description = Input.Description,
-        //     Gender = Input.Gender,
-        //     BirthDate = Input.BirthDate!.Value,
-        //     PhotoBase64 = Input.PhotoBase64,
-        //     MicrochipNumber = Input.MicrochipNumber,
-        //     IsAnUnclawnedCat = Input.IsAnUnclawnedCat,
-        //     Weight = Input.Weight,
-        //     WeightUnit = Input.WeightUnit,
-        // });
+        CreateCitizenDto createCitizenDto = MapToDto();
+
+        _ = citizenService.CreateAsync(createCitizenDto);
 
         return RedirectToPage(LocalRedirection.Citizens);
+    }
+
+    private CreateCitizenDto MapToDto()
+    {
+        return new()
+        {
+            Civility = Input.Civility,
+            FirstName = Input.FirstName,
+            LastName = Input.LastName,
+            Phone = Input.Phone,
+            CellPhone = Input.CellPhone,
+            CommunicationPreference = Input.CommunicationPreference,
+            LanguagePreference = Input.LanguagePreference,
+            Email = Input.Email,
+            StreetNumber = Input.StreetNumber,
+            StreetName = Input.StreetName,
+            Appartment = Input.Appartment,
+            City = Input.City,
+            Province = Input.Province,
+            PostalCode = Input.PostalCode,
+            Country = Input.Country,
+            PostOfficeBox = Input.PostOfficeBox,
+        };
     }
 }

--- a/src/Beagl.WebApp/Pages/Citizens/Create.cshtml.cs
+++ b/src/Beagl.WebApp/Pages/Citizens/Create.cshtml.cs
@@ -40,21 +40,21 @@ internal sealed class CreateCitizenModel(
         return new()
         {
             Civility = Input.Civility,
-            FirstName = Input.FirstName,
-            LastName = Input.LastName,
+            FirstName = Input.FirstName!,
+            LastName = Input.LastName!,
             Phone = Input.Phone,
             CellPhone = Input.CellPhone,
             CommunicationPreference = Input.CommunicationPreference,
             LanguagePreference = Input.LanguagePreference,
             Email = Input.Email,
-            StreetNumber = Input.StreetNumber,
-            StreetName = Input.StreetName,
+            StreetNumber = Input.StreetNumber!,
+            StreetName = Input.StreetName!,
             Appartment = Input.Appartment,
-            City = Input.City,
-            Province = Input.Province,
-            PostalCode = Input.PostalCode,
-            Country = Input.Country,
-            PostOfficeBox = Input.PostOfficeBox,
+            City = Input.City!,
+            Province = Input.Province!,
+            PostalCode = Input.PostalCode!,
+            Country = Input.Country!,
+            PostOfficeBox = Input.PostOfficeBox!,
         };
     }
 }

--- a/src/Beagl.WebApp/Pages/Citizens/Index.cshtml
+++ b/src/Beagl.WebApp/Pages/Citizens/Index.cshtml
@@ -34,7 +34,8 @@
                 <thead class="table-light">
                     <tr>
                         <th>@Localizer["Name"]</th>
-                        <th>@Localizer["Phones"]</th>
+                        <th>@Localizer["Phone"]</th>
+                        <th>@Localizer["Cell Phone"]</th>
                         <th>@Localizer["Email"]</th>
                         <th>@Localizer["Animal Count"]</th>
                         <th>@Localizer["Actions"]</th>
@@ -47,7 +48,8 @@
                         {
                             <tr>
                                 <td>@citizen.Name</td>
-                                <td>@citizen.PhoneNumbers?.FirstOrDefault()</td>
+                                <td>@citizen.Phone</td>
+                                <td>@citizen.CellPhone</td>
                                 <td>@citizen.Email</td>
                                 <td>@citizen.AnimalsCount</td>
                                 <td>
@@ -62,7 +64,7 @@
                     else
                     {
                         <tr>
-                            <td colspan="8" class="text-center">@Localizer["No citizens found."]</td>
+                            <td colspan="6" class="text-center">@Localizer["No citizens found."]</td>
                         </tr>
                     }
                 </tbody>

--- a/src/Beagl.WebApp/Pages/Citizens/Index.cshtml.cs
+++ b/src/Beagl.WebApp/Pages/Citizens/Index.cshtml.cs
@@ -44,7 +44,8 @@ internal sealed class IndexModel(
         {
             Id = citizen.Id,
             Name = citizen.Name,
-            PhoneNumbers = citizen.PhoneNumbers,
+            Phone = citizen.Phone,
+            CellPhone = citizen.CellPhone,
             Email = citizen.Email,
             AnimalsCount = citizen.AnimalsCount
         })];

--- a/src/Beagl.WebApp/Pages/Citizens/ViewModels/CreateCitizenViewModel.cs
+++ b/src/Beagl.WebApp/Pages/Citizens/ViewModels/CreateCitizenViewModel.cs
@@ -54,7 +54,7 @@ public class CreateCitizenViewModel
 	/// <summary>
 	/// Language preference (fr, en).
 	/// </summary>
-	//[Required(ErrorMessageResourceType = typeof(Create), ErrorMessageResourceName = "LanguagePreference_Required")]
+	[Required(ErrorMessageResourceType = typeof(Create), ErrorMessageResourceName = "LanguagePreference_Required")]
 	[Display(Name = "Language Preference")]
     public string? LanguagePreference { get; set; }
 

--- a/src/Beagl.WebApp/Pages/Citizens/ViewModels/CreateCitizenViewModel.cs
+++ b/src/Beagl.WebApp/Pages/Citizens/ViewModels/CreateCitizenViewModel.cs
@@ -14,7 +14,7 @@ public class CreateCitizenViewModel
 	/// Civility (e.g., Mr., Mrs., Ms., etc.)
 	/// </summary>
 	[Display(Name = "Civility")]
-	public string? Civility { get; set; }
+	public int Civility { get; set; }
 
 	/// <summary>
 	/// First name of the citizen.
@@ -49,14 +49,14 @@ public class CreateCitizenViewModel
 	/// </summary>
 	[Required(ErrorMessageResourceType = typeof(Create), ErrorMessageResourceName = "CommunicationPreference_Required")]
 	[Display(Name = "Communication Preference")]
-    public string? CommunicationPreference { get; set; }
+    public int CommunicationPreference { get; set; }
 
 	/// <summary>
 	/// Language preference (fr, en).
 	/// </summary>
 	[Required(ErrorMessageResourceType = typeof(Create), ErrorMessageResourceName = "LanguagePreference_Required")]
 	[Display(Name = "Language Preference")]
-    public string? LanguagePreference { get; set; }
+    public int LanguagePreference { get; set; }
 
 	/// <summary>
 	/// Email address.

--- a/src/Beagl.WebApp/Pages/Citizens/ViewModels/ListCitizensViewModel.cs
+++ b/src/Beagl.WebApp/Pages/Citizens/ViewModels/ListCitizensViewModel.cs
@@ -18,14 +18,19 @@ public class ListCitizensViewModel
     public required string Name { get; init; }
 
     /// <summary>
-    /// Gets the phone numbers of the citizen.
+	/// Phone number.
+	/// </summary>
+	public string? Phone { get; set; }
+
+    /// <summary>
+    /// Cell phone number.
     /// </summary>
-    public IEnumerable<string> PhoneNumbers { get; init; } = [];
+    public string? CellPhone { get; set; }
 
     /// <summary>
     /// Gets the email address of the citizen.
     /// </summary>
-    public string Email { get; init; } = string.Empty;
+    public string? Email { get; init; } = string.Empty;
 
     /// <summary>
     /// Gets the number of animals associated with the citizen.

--- a/src/Beagl.WebApp/Resources/Pages/Citizens/Index.fr.resx
+++ b/src/Beagl.WebApp/Resources/Pages/Citizens/Index.fr.resx
@@ -1,5 +1,110 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -7,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, ...</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, ...</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Citizens" xml:space="preserve">
     <value>Citoyens</value>
@@ -21,8 +126,8 @@
   <data name="Name" xml:space="preserve">
     <value>Nom</value>
   </data>
-  <data name="Phones" xml:space="preserve">
-    <value>Téléphones</value>
+  <data name="Phone" xml:space="preserve">
+    <value>Téléphone</value>
   </data>
   <data name="Email" xml:space="preserve">
     <value>Courriel</value>
@@ -44,5 +149,8 @@
   </data>
   <data name="Toggle Dropdown" xml:space="preserve">
     <value>Afficher le menu déroulant</value>
+  </data>
+  <data name="Cell Phone" xml:space="preserve">
+    <value>Cellulaire</value>
   </data>
 </root>

--- a/src/Beagl.WebApp/Resources/Pages/Citizens/Index.resx
+++ b/src/Beagl.WebApp/Resources/Pages/Citizens/Index.resx
@@ -1,5 +1,110 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -7,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, ...</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, ...</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Citizens" xml:space="preserve">
     <value>Citizens</value>
@@ -21,8 +126,8 @@
   <data name="Name" xml:space="preserve">
     <value>Name</value>
   </data>
-  <data name="Phones" xml:space="preserve">
-    <value>Phones</value>
+  <data name="Phone" xml:space="preserve">
+    <value>Phone</value>
   </data>
   <data name="Email" xml:space="preserve">
     <value>Email</value>
@@ -44,5 +149,8 @@
   </data>
   <data name="Toggle Dropdown" xml:space="preserve">
     <value>Toggle Dropdown</value>
+  </data>
+  <data name="Cell Phone" xml:space="preserve">
+    <value>Cell Phone</value>
   </data>
 </root>


### PR DESCRIPTION
This pull request introduces the initial implementation of the Citizen Management domain, including core domain models, value objects, repositories, DTOs, and integration with Entity Framework Core. The changes establish the foundation for creating, storing, and querying citizen data, including support for addresses, communication preferences, and language preferences.

**Domain Model and Value Objects**

* Added the `Citizen` aggregate root entity, including properties for person name, communication preferences, language, contact details, addresses, and audit information.
* Introduced value objects: `PersonName`, `Civility`, `CommunicationPreference`, and `LanguagePreference` to model personal and preference data in a type-safe manner. [[1]](diffhunk://#diff-139c48a9302535f7063bc2a4e027b2338b52cd6cb0962de98774d3c5c62538e0R1-R28) [[2]](diffhunk://#diff-10bdde9017e355e248dff4f107405f9d381dd8c5444e1bf49c5ee1f6a39d7cbcR1-R44) [[3]](diffhunk://#diff-c66a9b622221aa59e675acd21ce5d7c664b39c6960cf1f4ca9b781bdd929f8c9R1-R29) [[4]](diffhunk://#diff-8a9878fc155738583ff46c87873f922324fc1f742727cd67591283f20ddc5a9aR1-R24)
* Added the `Address` entity to represent postal addresses for citizens, with support for metadata and citizen association.

**Persistence Layer and EF Core Integration**

* Registered `Citizen` and `Address` entities in `ApplicationDbContext`, and configured their relationships, owned types, and property mappings using Fluent API. [[1]](diffhunk://#diff-fca98eaafc64984c1454f1e4c0a5374b9689689327e551e325745ebe34945963R7-R9) [[2]](diffhunk://#diff-fca98eaafc64984c1454f1e4c0a5374b9689689327e551e325745ebe34945963R46-R55) [[3]](diffhunk://#diff-fca98eaafc64984c1454f1e4c0a5374b9689689327e551e325745ebe34945963R105-R151)
* Implemented the `ICitizenRepository` interface and its concrete `CitizenRepository` for persisting citizens asynchronously. [[1]](diffhunk://#diff-e46e381abb8bbdbf306951018d3b3ac3fb069a9615c204608684d1461a065f91R1-R18) [[2]](diffhunk://#diff-d155369e9cb7c722d4d379bcbe16ad7ecff78a31d7f141e1580e5577446e0864R1-R23)

**Application Layer and DTOs**

* Added `CreateCitizenDto` for citizen creation and updated `CitizenListDto` to reflect the new domain model (e.g., replacing phone numbers collection with `Phone` and `CellPhone`). [[1]](diffhunk://#diff-aa8fa27a4956cff30065bf800722066e517eaf5281e3550b5ac46a3a8a745341R1-R89) [[2]](diffhunk://#diff-eeccc7084246ccb7eb3f77cedb55f2e1737b47dcb87e092bbaac42a06c873aeaL25-R37)
* Introduced `ICitizenService` for creating citizens asynchronously and an enum conversion helper (`EnumHelper`). [[1]](diffhunk://#diff-e7eafff1c3a25ef2e5653fb6e5d0a80419f230ae051b49a2c1a779053ded15dfR1-R20) [[2]](diffhunk://#diff-9adeb27ff2f4fcea2f6dd54857f1de06004a1a498e1757db1139f927474a9affR1-R21)

**Query Services**

* Updated `CitizenQueryService` to project citizens from the database into the new `CitizenListDto` structure, supporting paging and filtering.

These changes lay the groundwork for robust citizen management, ensuring strong domain modeling, type safety, and proper persistence practices.